### PR TITLE
Relax constraint on ansible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Limit Ansible to <2.5, since the os_quota module is broken when a Cinder
 # endpoint is not available. See
 # https://github.com/ansible/ansible/issues/41240.
-ansible>=2.3.1,<2.5.0
+ansible>=2.6.0


### PR DESCRIPTION
Now cinder is enabled we no longer have to workaround:
https://github.com/ansible/ansible/issues/41240

We need ansible greater than 2.6.0 otherwise stackhpc.os-networks
fails on task: "Ensure router is registered with neutron", with
message similar to:

TASK [stackhpc.os-networks : Ensure router is registered with neutron] ************
failed: [localhost] (item={u'project': u'admin', u'interfaces': [{u'portip': u'10.65.0.2', u'subnet': u'internal', u'net': u'internal'}, {u'portip': u'10.69.0.1', u'subnet': u'provision-net', u'net': u'provision-net'}], u'name': u'provision'}) => {"changed": false, "failed": true, "item": {"interfaces": [{"net": "internal", "portip": "10.65.0.2", "subnet": "internal"}, {"net": "provision-net", "portip": "10.69.0.1", "subnet": "provision-net"}], "name": "provision", "project": "admin"}, "msg": "subnet {'portip': '10.65.0.2', 'subnet': 'internal', 'net': 'internal'} not found"}